### PR TITLE
Add Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,3 @@
-
 on:
   push:
     branches: [main]
@@ -98,3 +97,50 @@ jobs:
 
       - name: Publish release distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  build_and_push_docker:
+    name: Build and Push Docker Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
+    env:
+      IMAGE_NAME: qabot
+      IMAGE_REGISTRY: ghcr.io
+      IMAGE_REPOSITORY: hardbyte
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{env.IMAGE_REGISTRY}}/${{env.IMAGE_REPOSITORY}}/${{env.IMAGE_NAME}}
+          tags: |
+            type=sha
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.IMAGE_REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,18 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry
-RUN curl -sSL https://install.python-poetry.org | python3 -
+ARG POETRY_VERSION=1.8
+
+ENV POETRY_HOME=/opt/poetry
+ENV POETRY_NO_INTERACTION=1
+ENV POETRY_VIRTUALENVS_IN_PROJECT=1
+ENV POETRY_VIRTUALENVS_CREATE=1
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+# Tell Poetry where to place its cache and virtual environment
+ENV POETRY_CACHE_DIR=/opt/.cache
+
+RUN pip install "poetry==${POETRY_VERSION}"
 
 # Set working directory
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,46 +1,66 @@
 # Multi-stage Dockerfile to build a lean Docker image for qabot
 
 # Stage 1: Build stage
-FROM python:3.11-slim AS build
+FROM python:3.12 AS build
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN <<EOT
+apt-get update -qy
+apt-get install -qyy \
+    -o APT::Install-Recommends=false \
+    -o APT::Install-Suggests=false \
     build-essential \
-    curl \
-    && rm -rf /var/lib/apt/lists/*
-
+    ca-certificates
+rm -rf /var/lib/apt/lists/*
+EOT
 # Install Poetry
-ARG POETRY_VERSION=1.8
-
+ARG POETRY_VERSION=1.8.3
 ENV POETRY_HOME=/opt/poetry
+ENV VIRTUAL_ENV=/app/.venv
 ENV POETRY_NO_INTERACTION=1
-ENV POETRY_VIRTUALENVS_IN_PROJECT=1
-ENV POETRY_VIRTUALENVS_CREATE=1
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
-# Tell Poetry where to place its cache and virtual environment
-ENV POETRY_CACHE_DIR=/opt/.cache
+ENV POETRY_VIRTUALENVS_CREATE=false
+ENV POETRY_VIRTUALENVS_IN_PROJECT=false
 
 RUN pip install "poetry==${POETRY_VERSION}"
 
 # Set working directory
 WORKDIR /app
 
-# Copy project files
-COPY pyproject.toml poetry.lock ./
-COPY qabot ./qabot
+# Copy pyproject.toml and poetry.lock to install dependencies
+COPY pyproject.toml poetry.lock /app/
 
-# Install dependencies
-RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
+# Install dependencies without the application code
+RUN --mount=type=cache,target=/root/.cache \
+    python3 -m venv ${VIRTUAL_ENV} && \
+    poetry install --no-root
 
-# Stage 2: Final stage
-FROM python:3.11-slim
+# Copy the application code to install the app itself
+COPY . /app
+
+# Install only the application (no dependencies)
+RUN --mount=type=cache,target=/root/.cache \
+    poetry install --no-dev --no-interaction --no-ansi
+
+# Runtime Stage
+FROM python:3.12
+
+# Set environment variables for Python
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+ENV VIRTUAL_ENV=/app/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
 
 # Set working directory
 WORKDIR /app
 
 # Copy only the necessary files from the build stage
+# Copy the virtual environment and application code from the build stage
+COPY --from=build /app/.venv /app/.venv
 COPY --from=build /app /app
 
+
 # Set the entrypoint to the qabot command line tool
-ENTRYPOINT ["qabot"]
+ENTRYPOINT ["python", "-m", "qabot.cli"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+# Multi-stage Dockerfile to build a lean Docker image for qabot
+
+# Stage 1: Build stage
+FROM python:3.11-slim AS build
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Poetry
+RUN curl -sSL https://install.python-poetry.org | python3 -
+
+# Set working directory
+WORKDIR /app
+
+# Copy project files
+COPY pyproject.toml poetry.lock ./
+COPY qabot ./qabot
+
+# Install dependencies
+RUN poetry config virtualenvs.create false && poetry install --no-interaction --no-ansi
+
+# Stage 2: Final stage
+FROM python:3.11-slim
+
+# Set working directory
+WORKDIR /app
+
+# Copy only the necessary files from the build stage
+COPY --from=build /app /app
+
+# Set the entrypoint to the qabot command line tool
+ENTRYPOINT ["qabot"]

--- a/README.md
+++ b/README.md
@@ -190,7 +190,27 @@ Result:
 264308334 confirmed cases
 ```
 
+## Docker Usage
 
+You can build and run the Docker image for `qabot` using the following instructions:
+
+### Building the Docker Image
+
+To build the Docker image, run the following command in the root directory of the repository:
+
+```bash
+docker build -t qabot .
+```
+
+### Running the Docker Image
+
+To run the Docker image, use the following command:
+
+```bash
+docker run --rm -e OPENAI_API_KEY=your_openai_api_key qabot -w -q "How many Hospitals are there located in Beijing"
+```
+
+Replace `your_openai_api_key` with your actual OpenAI API key.
 
 ## Ideas
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ docker build -t qabot .
 To run the Docker image, use the following command:
 
 ```bash
-docker run --rm -e OPENAI_API_KEY=your_openai_api_key qabot -w -q "How many Hospitals are there located in Beijing"
+docker run --rm -e OPENAI_API_KEY=your_openai_api_key ghcr.io/hardbyte/qabot -w -q "How many Hospitals are there located in Beijing"
 ```
 
 Replace `your_openai_api_key` with your actual OpenAI API key.


### PR DESCRIPTION
Fixes #27

Add a Dockerfile and CI workflow for building and pushing Docker images for `qabot`.

* **Dockerfile**:
  - Add a multi-stage Dockerfile to build a lean Docker image.
  - Use `python:3.11-slim` as the base image.
  - Install dependencies using `poetry`.
  - Set the entrypoint to the `qabot` command line tool.

* **CI Workflow**:
  - Add a new job `build_and_push_docker` to build and push the Docker image.
  - Use `docker/build-push-action@v4` to build and push the Docker image to GitHub.
  - Set the Docker image name to `ghcr.io/hardbyte/qabot`.
  - Add steps for Docker meta, login, and build/push.
  - Add permissions and environment variables for the `build_and_push_docker` job.

* **README.md**:
  - Add instructions for building and running the Docker image.
  - Include a section on how to use the Docker image.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/hardbyte/qabot/issues/27?shareId=2cd19280-d416-47fc-a6e7-87640c212e2d).